### PR TITLE
Feature to control sample rate of data collection

### DIFF
--- a/host/lib/code/data_collection.cpp
+++ b/host/lib/code/data_collection.cpp
@@ -110,7 +110,7 @@ void DataCollection:: process_sample(uint32_t *data_packet, int start_idx)
         idx++;
     }
 
-    for (int i = 0; i < MAX_NUM_FT_READINGS; i++) {
+    for (int i = 0; i < FORCE_SAMPLE_NUM_DEGREES; i++) {
         proc_sample.force_torque[i] = *reinterpret_cast<float *> (&data_packet[idx++]);
     }
 
@@ -211,7 +211,7 @@ void DataCollection::write_csv_headers() {
         // if (i < dc_meta.num_motors) myFile << ",";
     }
 
-    for (int i = 1; i <= MAX_NUM_FT_READINGS; i++) {
+    for (int i = 1; i <= FORCE_SAMPLE_NUM_DEGREES; i++) {
 
         if (i <= 3){
             myFile << "FORCE_" << i;
@@ -219,7 +219,7 @@ void DataCollection::write_csv_headers() {
             myFile << "TORQUE_" << i;
         }
         
-        if (i < MAX_NUM_FT_READINGS) myFile << ",";
+        if (i < FORCE_SAMPLE_NUM_DEGREES) myFile << ",";
 
         // myFile << ",";
     }
@@ -254,12 +254,12 @@ void DataCollection::process_and_write_data() {
 
         // cout << "before writing torque forces" << endl;
 
-        for (int j = 0; j < MAX_NUM_FT_READINGS; j++){
+        for (int j = 0; j < FORCE_SAMPLE_NUM_DEGREES; j++){
 
             // cout << j << endl;
             myFile << proc_sample.force_torque[j];
 
-            if (j < MAX_NUM_FT_READINGS - 1) {
+            if (j < FORCE_SAMPLE_NUM_DEGREES - 1) {
                 myFile << ",";
             }
 

--- a/host/lib/code/data_collection.cpp
+++ b/host/lib/code/data_collection.cpp
@@ -323,7 +323,7 @@ bool DataCollection :: init(uint8_t boardID, bool usePSIO, bool useSampleRate, i
 
                 if(use_sample_rate){
                     udp_transmit(sock_id, (char *)HOST_READY_CMD_W_SAMPLE_RATE, sizeof(HOST_READY_CMD_W_SAMPLE_RATE));
-                    udp_transmit(sock_id, (void *) &sample_rate, sizeof(sample_rate));
+                    udp_transmit(sock_id, (int *) &sample_rate, sizeof(sample_rate));
                 }
                 
                 

--- a/host/lib/code/data_collection.cpp
+++ b/host/lib/code/data_collection.cpp
@@ -402,7 +402,8 @@ bool DataCollection :: start()
         return 1;
     }
 
-    while (udp_nonblocking_receive(sock_id, data_packet, dc_meta.data_packet_size) > 0) {cout << "clearing udp packet buffer" <<std::endl;}
+    // clearing udp buffer of remaining packets not captured during data collection
+    while (udp_nonblocking_receive(sock_id, data_packet, dc_meta.data_packet_size) > 0) {}
 
     return true;
 }
@@ -420,12 +421,7 @@ bool DataCollection :: stop()
 
     stop_data_collection_flag = true;
 
-    while (udp_nonblocking_receive(sock_id, data_packet, dc_meta.data_packet_size) > 0) {cout << "we clearing" <<std::endl;}
-
     pthread_join(collect_data_t, nullptr);
-
-    // clear the udp buffer by reading until the buffer is empty
-    while (udp_nonblocking_receive(sock_id, data_packet, dc_meta.data_packet_size) > 0) {cout << "we clearing 1" <<std::endl;}
 
     myFile.close();
 
@@ -441,8 +437,6 @@ bool DataCollection :: stop()
     collect_data_ret = true;
 
     usleep(1000);
-
-    while (udp_nonblocking_receive(sock_id, data_packet, dc_meta.data_packet_size) > 0) {cout << "we clearing 2" <<std::endl;}
 
     return true;
 }

--- a/host/lib/code/data_collection.cpp
+++ b/host/lib/code/data_collection.cpp
@@ -213,11 +213,9 @@ void DataCollection::write_csv_headers() {
 
     for (int i = 1; i <= FORCE_SAMPLE_NUM_DEGREES; i++) {
 
-        if (i <= 3){
+        if (i <= FORCE_SAMPLE_NUM_DEGREES){
             myFile << "FORCE_" << i;
-        } else {
-            myFile << "TORQUE_" << i;
-        }
+        } 
         
         if (i < FORCE_SAMPLE_NUM_DEGREES) myFile << ",";
 

--- a/host/lib/data_collection.h
+++ b/host/lib/data_collection.h
@@ -20,6 +20,7 @@ http://www.cisst.org/cisst/license.txt.
 
 #include <chrono>
 #include <string>
+#include <stdint.h>
 
 #include "data_collection_shared.h"
 
@@ -76,6 +77,8 @@ class DataCollection {
 
         bool use_ps_io = false;
 
+        bool use_sample_rate = false;
+
         bool stop_data_collection_flag;
 
         bool collect_data_ret;
@@ -87,6 +90,8 @@ class DataCollection {
         int udp_data_packets_recvd_count = 0;
 
         int packet_misses_counter = 0;
+
+        uint16_t sample_rate = 0;
 
         std::ofstream myFile;
 
@@ -111,7 +116,7 @@ class DataCollection {
         pthread_t collect_data_t;
     public:
         DataCollection();
-        bool init(uint8_t boardID, bool usePSIO);
+        bool init(uint8_t boardID, bool usePSIO, bool useSampleRate, int sample_rate);
         bool start();
         bool stop();
         bool terminate();

--- a/host/lib/data_collection.h
+++ b/host/lib/data_collection.h
@@ -55,6 +55,7 @@ class DataCollection {
             float encoder_velocity[MAX_NUM_ENCODERS];
             uint16_t motor_current[MAX_NUM_MOTORS];
             uint16_t motor_status[MAX_NUM_MOTORS];
+            float force_torque[MAX_NUM_FT_READINGS];
             uint32_t digital_io;
             uint32_t mio_pins;
         } proc_sample;

--- a/host/lib/data_collection.h
+++ b/host/lib/data_collection.h
@@ -55,7 +55,7 @@ class DataCollection {
             float encoder_velocity[MAX_NUM_ENCODERS];
             uint16_t motor_current[MAX_NUM_MOTORS];
             uint16_t motor_status[MAX_NUM_MOTORS];
-            float force_torque[MAX_NUM_FT_READINGS];
+            float force_torque[FORCE_SAMPLE_NUM_DEGREES];
             uint32_t digital_io;
             uint32_t mio_pins;
         } proc_sample;

--- a/host/src/dvrk-data-collection-host.cpp
+++ b/host/src/dvrk-data-collection-host.cpp
@@ -100,7 +100,9 @@ int main(int argc, char *argv[])
     bool startFlag = false;
     bool timedCaptureFlag = false;
     bool use_ps_io_flag = false;
+    bool use_sample_rate = false;
     uint8_t boardID; 
+    int sample_rate = 0;
     
 
     // cmd line variables
@@ -153,6 +155,18 @@ int main(int argc, char *argv[])
                 }
             }
 
+            else if (argv[i][1] == 's'){
+                if (!isInteger(argv[i+1])) {
+                    cout << "[ERROR] invalid sample rate value " << argv[i+1] << " for timed capture. Pass in Integer" << endl;
+                    return -1;
+                } else {
+                    use_sample_rate = true;
+                    sample_rate = atoi(argv[i+1]);
+                    cout << " Sample Rate set to " << sample_rate << "Hz" << endl;
+                    i+=1;
+                }
+            }
+
             else if (argv[i][1] == 'i' ) {
                 use_ps_io_flag = true;
                 cout << "PS IO pins will be included in data packet!" << endl;
@@ -170,7 +184,7 @@ int main(int argc, char *argv[])
     DataCollection *DC = new DataCollection();
     bool stop_data_collection = false;
 
-    if (!DC->init(boardID, use_ps_io_flag)) {
+    if (!DC->init(boardID, use_ps_io_flag, use_sample_rate, sample_rate)) {
         return -1;
     }
 

--- a/shared/data_collection_shared.h
+++ b/shared/data_collection_shared.h
@@ -24,7 +24,7 @@ http://www.cisst.org/cisst/license.txt.
 
 const unsigned int MAX_NUM_ENCODERS = 8;
 const unsigned int MAX_NUM_MOTORS = 10;
-const unsigned int MAX_NUM_FT_READINGS = 6;
+// const unsigned int MAX_NUM_FT_READINGS = 6;
 
 // Default MTU=1500 (does not count 18 bytes for Ethernet frame header and CRC)
 const unsigned int MTU_DEFAULT = 1500;
@@ -40,6 +40,8 @@ const unsigned int UDP_MAX_QUADLET_PER_PACKET = UDP_REAL_MTU/4;
 
 // Arbitrary, used as a const for consistency. Can be changed later
 const unsigned int CMD_MAX_STRING_SIZE = 100;
+
+const unsigned int FORCE_SAMPLE_NUM_DEGREES = 3;
 
 // Data collection meta-data
 struct DataCollectionMeta {

--- a/shared/data_collection_shared.h
+++ b/shared/data_collection_shared.h
@@ -24,6 +24,7 @@ http://www.cisst.org/cisst/license.txt.
 
 const unsigned int MAX_NUM_ENCODERS = 8;
 const unsigned int MAX_NUM_MOTORS = 10;
+const unsigned int MAX_NUM_FT_READINGS = 6;
 
 // Default MTU=1500 (does not count 18 bytes for Ethernet frame header and CRC)
 const unsigned int MTU_DEFAULT = 1500;
@@ -62,6 +63,7 @@ enum StateMachineReturnCodes {
     SM_OUT_OF_SYNC,
     SM_UDP_INVALID_HOST_ADDR,
     SM_FAILED_TO_CREATE_THREAD,
+    SM_FORCE_SENSOR_FAIL,
 };
 
 // Commands Sent between Host and Zynq

--- a/shared/data_collection_shared.h
+++ b/shared/data_collection_shared.h
@@ -73,6 +73,7 @@ enum StateMachineReturnCodes {
     #define HOST_START_DATA_COLLECTION                      "HOST: START DATA COLLECTION"
     #define HOST_READY_CMD                                  "HOST: READY FOR DATA COLLECTION"
     #define HOST_READY_CMD_W_PS_IO                          "HOST: READY FOR DATA COLLECTION - WITH PS IO"
+    #define HOST_READY_CMD_W_SAMPLE_RATE                    "HOST: READY FOR DATA COLLECTION - WITH SAMPLE RATE"
     #define HOST_RECVD_METADATA                             "HOST: RECEIVED METADATA"
     #define HOST_STOP_DATA_COLLECTION                       "HOST: STOP DATA COLLECTION"
     #define HOST_TERMINATE_SERVER                           "HOST: TERMINATE SERVER"

--- a/zynq/dvrk-data-collection-zynq.cpp
+++ b/zynq/dvrk-data-collection-zynq.cpp
@@ -576,7 +576,7 @@ static bool load_data_packet(Dvrk_Controller dvrk_controller, uint32_t *data_pac
 
 
             uint32_t raw_cmd_current;
-            Port->ReadQuadlet(Port->GetBoardId(0), ((i+1) << 4) | 1, raw_cmd_current);
+            dvrk_controller.Port->ReadQuadlet(dvrk_controller.Port->GetBoardId(0), ((i+1) << 4) | 1, raw_cmd_current);
             // int16_t raw_cmd_current_16_bit = static_cast<int16_t>(raw_cmd_current);
             // uint16_t cmd_current_casted = *reinterpret_cast<uint16_t *>(&raw_cmd_current_16_bit);
 

--- a/zynq/dvrk-data-collection-zynq.cpp
+++ b/zynq/dvrk-data-collection-zynq.cpp
@@ -412,7 +412,7 @@ static bool load_data_packet(Dvrk_Controller dvrk_controller, uint32_t *data_pac
     // clock_gettime(CLOCK_MONOTONIC, &next_wakeup);
     // long period_ns = (long)(1e9 / SAMPLE_RATE);
 
-    double adjusted_sample_rate = ((double)SAMPLE_RATE) / 0.9236  ;
+    // double adjusted_sample_rate = ((double)SAMPLE_RATE) / 0.9236  ;
     // double Tp    = 1.0 / (double) SAMPLE_RATE;  // ideal period (s)
     // double Kp    = .12;              // proportional gain (tune this)
     // double Tnext = Tp;               // next absolute deadline
@@ -525,11 +525,12 @@ static bool load_data_packet(Dvrk_Controller dvrk_controller, uint32_t *data_pac
             // overhead_time = 1;
             
 
-            while (elapsed_seconds < ((1.0 / ( (double) SAMPLE_RATE)) - (2 * get_time_bias) - (overhead_time) )) {
+            while (elapsed_seconds < ((1.0 / ( (double) SAMPLE_RATE)) - (2 * get_time_bias) - (overhead_time) + (overhead_time/4))) {
                 clock_gettime(CLOCK_MONOTONIC_RAW, &t_end);
                 elapsed_seconds = double(t_end.tv_sec  - t_start.tv_sec) + double(t_end.tv_nsec - t_start.tv_nsec) * 1e-9;
                 
             }
+
         }
 
         // overhead_start_time = std::chrono::high_resolution_clock::now();

--- a/zynq/dvrk-data-collection-zynq.cpp
+++ b/zynq/dvrk-data-collection-zynq.cpp
@@ -571,8 +571,16 @@ static bool load_data_packet(Dvrk_Controller dvrk_controller, uint32_t *data_pac
         // DATA 4 & 5: motor current and motor status (for num_motors)
         for (int i = 0; i < num_motors; i++) {
             uint32_t motor_curr = dvrk_controller.Board->GetMotorCurrent(i); 
-            uint32_t motor_status = dvrk_controller.Board->GetMotorStatus(i);
-            data_packet[count++] = (uint32_t)(((motor_status & 0x0000FFFF) << 16) | (motor_curr & 0x0000FFFF));
+            // uint32_t motor_status = dvrk_controller.Board->GetMotorStatus(i);
+            // data_packet[count++] = (uint32_t)(((motor_status & 0x0000FFFF) << 16) | (motor_curr & 0x0000FFFF));
+
+
+            uint32_t raw_cmd_current;
+            Port->ReadQuadlet(Port->GetBoardId(0), ((i+1) << 4) | 1, raw_cmd_current);
+            // int16_t raw_cmd_current_16_bit = static_cast<int16_t>(raw_cmd_current);
+            // uint16_t cmd_current_casted = *reinterpret_cast<uint16_t *>(&raw_cmd_current_16_bit);
+
+            data_packet[count++] = (uint32_t)(((raw_cmd_current & 0x0000FFFF) << 16) | (motor_curr & 0x0000FFFF));
         }
 
          // DATA 6: force readings

--- a/zynq/dvrk-data-collection-zynq.cpp
+++ b/zynq/dvrk-data-collection-zynq.cpp
@@ -492,9 +492,9 @@ static uint16_t calculate_quadlets_per_sample(uint8_t num_encoders, uint8_t num_
     // MIO Pins (optional, used if PS IO is enabled ) 4 bits -> pad 32 bits         [1 quadlet * MIO PINS]  
     // Force Torque Readings -> 6 * 32 bits                                         [1 quadlet * 6 Fore/Torque Readings]                 
     if (use_ps_io_flag){
-        return (1 + 1 + 1 + (2*(num_encoders)) + (num_motors) + 6);
+        return (1 + 1 + 1 + (2*(num_encoders)) + (num_motors) + FORCE_SAMPLE_NUM_DEGREES);
     } else {
-        return (1 + (2*(num_encoders)) + (num_motors) + 6);
+        return (1 + (2*(num_encoders)) + (num_motors) + FORCE_SAMPLE_NUM_DEGREES);
     }
     
 }

--- a/zynq/dvrk-data-collection-zynq.cpp
+++ b/zynq/dvrk-data-collection-zynq.cpp
@@ -435,7 +435,7 @@ static bool load_data_packet(Dvrk_Controller dvrk_controller, uint32_t *data_pac
             sample_end_time = std::chrono::high_resolution_clock::now();
             double sample_processing_time = convert_chrono_duration_to_float(sample_start_time, sample_end_time) + usleep_bias + chrono_time_bias;
 
-            double delay_for_target_sample_rate = calculate_sample_rate_delay(1000, sample_processing_time);
+            double delay_for_target_sample_rate = calculate_sample_rate_delay(SAMPLE_RATE, sample_processing_time);
             double step = (delay_for_target_sample_rate * 1000000000.0);
 
             ts.tv_sec = 0;

--- a/zynq/dvrk-data-collection-zynq.cpp
+++ b/zynq/dvrk-data-collection-zynq.cpp
@@ -103,25 +103,23 @@ int sample_count = 0;
 // for emio timeout error
 int32_t emio_read_error_counter = 0; 
 
-// start time for data collection timestamps
-double usleep_bias = 0; 
-double chrono_time_bias = 0;
+// last timestamp from last capture
 double last_timestamp = 0;
 
+// timespec vaiables for getting timestamp using gettime() method
+// with CLOCK_MONOTONIC_RAW. 
+
 timespec t_data_collection_start;
+
+// keeps track of deadline to control sample rate
 timespec deadline;
+
+// expected period of sample capture
 long period_ns;
 
+// global sample rate variable to change sample rate
 int SAMPLE_RATE = 0;
 bool useSampleRate = false;
-double get_time_bias = 0;
-double last_time_diff = 0;
-
-
-// uint16_t target_sample_rate = 2000;
-// struct timespec ts;
-
-double timestamp_offset;
 
 // FLAG set when the host terminates data collection
 bool stop_data_collection_flag = false;


### PR DESCRIPTION
Byy using a  "-s <sample rate int>", you can control the sample rate of the data captures. There is no upper bound (other than the range of a signed int) on the sample rate you set. If it passes the max sample rate achievable by the dvrk controller, it will simply collect at that sample rate. After a couple of seconds of data collection, the measured sample rate should be within the target sample rate with a +-.1 tolerance.