### PR TITLE
Increased Timestamp Precision from float to double

### DIFF
--- a/host/lib/code/data_collection.cpp
+++ b/host/lib/code/data_collection.cpp
@@ -213,7 +213,7 @@ void DataCollection::process_and_write_data() {
     for (int i = 0; i < dc_meta.data_packet_size / 4; i += dc_meta.size_of_sample) {
         process_sample(data_packet, i);
 
-        myFile << proc_sample.timestamp << ",";
+        myFile << std::setprecision(17) << proc_sample.timestamp << ",";
 
         for (int j = 0; j < dc_meta.num_encoders; j++) {
             myFile << proc_sample.encoder_position[j] << ",";

--- a/host/lib/code/data_collection.cpp
+++ b/host/lib/code/data_collection.cpp
@@ -92,9 +92,7 @@ void DataCollection:: process_sample(uint32_t *data_packet, int start_idx)
 
     uint64_t raw_64bit_timestamp = (timestamp_high << 32) | (timestamp_low);
 
-    uint64_t timestamp_uint64 = *reinterpret_cast<uint64_t *>(&raw_64bit_timestamp);
-
-    proc_sample.timestamp = static_cast<double> (timestamp_uint64);
+    proc_sample.timestamp = *reinterpret_cast<double *>(&raw_64bit_timestamp);
 
     for (int i = 0; i < dc_meta.num_encoders; i++) {
         proc_sample.encoder_position[i] = *reinterpret_cast<int32_t *> (&data_packet[idx++]);

--- a/host/lib/code/data_collection.cpp
+++ b/host/lib/code/data_collection.cpp
@@ -213,7 +213,7 @@ void DataCollection::process_and_write_data() {
     for (int i = 0; i < dc_meta.data_packet_size / 4; i += dc_meta.size_of_sample) {
         process_sample(data_packet, i);
 
-        myFile << std::setprecision(17) << proc_sample.timestamp << ",";
+        myFile << setprecision(17) << proc_sample.timestamp << ",";
 
         for (int j = 0; j < dc_meta.num_encoders; j++) {
             myFile << proc_sample.encoder_position[j] << ",";

--- a/host/lib/code/data_collection.cpp
+++ b/host/lib/code/data_collection.cpp
@@ -86,7 +86,15 @@ void DataCollection:: process_sample(uint32_t *data_packet, int start_idx)
 
     int idx = start_idx;
 
-    proc_sample.timestamp = *reinterpret_cast<float *> (&data_packet[idx++]);
+
+    uint64_t timestamp_high = data_packet[idx++];
+    uint32_t timestamp_low = data_packet[idx++];
+
+    uint64_t raw_64bit_timestamp = (timestamp_high << 32) | (timestamp_low);
+
+    uint64_t timestamp_uint64 = *reinterpret_cast<uint64_t *>(&raw_64bit_timestamp);
+
+    proc_sample.timestamp = static_cast<double> (timestamp_uint64);
 
     for (int i = 0; i < dc_meta.num_encoders; i++) {
         proc_sample.encoder_position[i] = *reinterpret_cast<int32_t *> (&data_packet[idx++]);

--- a/host/lib/code/data_collection.cpp
+++ b/host/lib/code/data_collection.cpp
@@ -22,6 +22,7 @@ http://www.cisst.org/cisst/license.txt.
 #include <fstream>
 #include <string>
 #include <pthread.h>
+#include <iomanip>
 
 #include "udp_tx.h"
 #include "data_collection.h"
@@ -213,7 +214,7 @@ void DataCollection::process_and_write_data() {
     for (int i = 0; i < dc_meta.data_packet_size / 4; i += dc_meta.size_of_sample) {
         process_sample(data_packet, i);
 
-        myFile << setprecision(17) << proc_sample.timestamp << ",";
+        myFile << setprecision(12) << proc_sample.timestamp << ",";
 
         for (int j = 0; j < dc_meta.num_encoders; j++) {
             myFile << proc_sample.encoder_position[j] << ",";

--- a/host/lib/data_collection.h
+++ b/host/lib/data_collection.h
@@ -51,7 +51,7 @@ class DataCollection {
         };
 
         struct ProcessedSample {
-            float timestamp;
+            double timestamp;
             int32_t encoder_position[MAX_NUM_ENCODERS];
             float encoder_velocity[MAX_NUM_ENCODERS];
             uint16_t motor_current[MAX_NUM_MOTORS];

--- a/zynq/dvrk-data-collection-zynq.cpp
+++ b/zynq/dvrk-data-collection-zynq.cpp
@@ -317,7 +317,7 @@ static uint16_t calculate_quadlets_per_sample(uint8_t num_encoders, uint8_t num_
 
     // 1 quadlet = 4 bytes
 
-    // Timestamp (32 bit)                                                           [1 quadlet]
+    // Timestamp (Double -> 64 bits stored as two seperate quadlets)                                                           [1 quadlet]
     // Encoder Position (32 * num of encoders)                                      [1 quadlet * num of encoders]
     // Encoder Velocity Predicted (64 * num of encoders -> truncated to 32bits)     [1 quadlet * num of encoders]
     // Motur Current and Motor Status (32 * num of Motors -> each are 16 bits)      [1 quadlet * num of motors]

--- a/zynq/dvrk-data-collection-zynq.cpp
+++ b/zynq/dvrk-data-collection-zynq.cpp
@@ -324,9 +324,9 @@ static uint16_t calculate_quadlets_per_sample(uint8_t num_encoders, uint8_t num_
     // Digtial IO Values  (optional, used if PS IO is enabled ) 32 bits             [1 quadlet * digital IO]
     // MIO Pins (optional, used if PS IO is enabled ) 4 bits -> pad 32 bits         [1 quadlet * MIO PINS]                  
     if (use_ps_io_flag){
-        return (1 + 1 + 1 + (2*(num_encoders)) + (num_motors));
+        return (2 + 1 + 1 + (2*(num_encoders)) + (num_motors));
     } else {
-        return (1 + (2*(num_encoders)) + (num_motors));
+        return (2 + (2*(num_encoders)) + (num_motors));
     }
     
 }
@@ -389,8 +389,14 @@ static bool load_data_packet(Dvrk_Controller dvrk_controller, uint32_t *data_pac
 
         last_timestamp = time_elapsed;
 
-        float time_elapsed_float = static_cast<float>(time_elapsed);
-        data_packet[count++] = *reinterpret_cast<uint32_t *> (&time_elapsed_float);
+        uint64_t timestamp_uint64 = *reinterpret_cast<uint64_t *>(&time_elapsed);
+
+        uint32_t timestamp_high = (timestamp_uint64  >> 32);
+        uint32_t timestamp_low =  (uint32_t) (timestamp_uint64 & 0xFFFFFFFF);
+
+        // float time_elapsed_float = static_cast<float>(time_elapsed);
+        data_packet[count++] = timestamp_high;
+        data_packet[count++] = timestamp_low;
 
         // DATA 2: encoder position
         for (int i = 0; i < num_encoders; i++) {


### PR DESCRIPTION
Needed to increase precision given the difference between consecutive stamps are much less than a millisecond (less than .0001s) for high sample rates that yield low periods. The zynq program stores the timestamp into two seperate 32 bit values before sending it to the host. the host recombines those values into a double which is stored in the csv file.